### PR TITLE
Make the task progress stateless.

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,11 +1,9 @@
 package main
 
-import (
-	"github.com/hryang/stable-diffusion-webui-proxy/pkg/proxy"
-)
+import "github.com/hryang/stable-diffusion-webui-proxy/pkg/agent"
 
 func main() {
-	s := proxy.NewAgent(
+	s := agent.NewAgent(
 		"http://sd.fc-stable-diffusion.1050834996213541.cn-hangzhou.fc.devsapp.net/")
 	defer s.Close()
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,4 +1,4 @@
-package proxy
+package agent
 
 import (
 	"bytes"

--- a/pkg/datastore/sqlite.go
+++ b/pkg/datastore/sqlite.go
@@ -16,7 +16,8 @@ func NewSQLiteDatastore(name string) *SQLiteDatastore {
 	if err != nil {
 		panic(fmt.Errorf("failed to open database: %v", err))
 	}
-	_, err = db.Exec("CREATE TABLE mytable (key text not null primary key, value text);")
+	// TODO: make table name configurable.
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS mytable (key text not null primary key, value text);")
 	if err != nil {
 		panic(fmt.Errorf("failed to create table: %v", err))
 	}

--- a/pkg/proxy/agent.go
+++ b/pkg/proxy/agent.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"reflect"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/hryang/stable-diffusion-webui-proxy/pkg/datastore"
@@ -18,15 +19,17 @@ import (
 )
 
 type Agent struct {
-	Target    *url.URL               // the target server address
-	Echo      *echo.Echo             // the echo server for reverse proxy
-	Proxy     *httputil.ReverseProxy // the underlying reverse proxy
-	Datastore datastore.Datastore    // the datastore to store the task states
+	Target     *url.URL               // the target server address
+	Echo       *echo.Echo             // the echo server for reverse proxy
+	Proxy      *httputil.ReverseProxy // the underlying reverse proxy
+	Datastore  datastore.Datastore    // the datastore to store the task states
+	HttpClient *http.Client           // the http client
 }
 
 func NewAgent(endpoint string) *Agent {
 	a := &Agent{
-		Echo: echo.New(),
+		Echo:       echo.New(),
+		HttpClient: &http.Client{},
 	}
 
 	//a.Echo.Debug = true
@@ -37,9 +40,8 @@ func NewAgent(endpoint string) *Agent {
 
 	a.Proxy = httputil.NewSingleHostReverseProxy(a.Target)
 
-	a.Datastore = datastore.NewSQLiteDatastore(":memory:")
+	a.Datastore = datastore.NewSQLiteDatastore("./test.db")
 
-	a.Echo.POST("/internal/progress", a.progressHandler)
 	a.Echo.GET("/queue/join", a.queueJoinHandler)
 
 	// Handler for all other cases.
@@ -48,7 +50,6 @@ func NewAgent(endpoint string) *Agent {
 		req.Host = a.Target.Host
 		req.URL.Host = a.Target.Host
 		req.URL.Scheme = a.Target.Scheme
-		a.Echo.Logger.Info(req)
 		a.Proxy.ServeHTTP(c.Response(), c.Request())
 		return nil
 	})
@@ -66,53 +67,22 @@ func (a *Agent) Close() error {
 	return a.Datastore.Close()
 }
 
-func (a *Agent) progressHandler(c echo.Context) error {
-	// /internal/progress requests should be handled by proxy instead of agent, so return error.
-	return fmt.Errorf("internal error: agent should not receive the /internal/progress request")
-
-	req := c.Request()
-	req.Host = a.Target.Host
-	req.URL.Host = a.Target.Host
-	req.URL.Scheme = a.Target.Scheme
-
-	// Get task id from request.
-	body, err := io.ReadAll(c.Request().Body)
-	if err != nil {
-		return err
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(body, &m); err != nil {
-		return err
-	}
-	taskId := m["id_task"].(string)
-
-	// The http body is a stream and can be read once only.
-	// So we have to restore the request body for serving.
-	c.Request().Body = io.NopCloser(bytes.NewBuffer(body))
-
-	// Get task state from DB.
-	state, err := a.Datastore.Get(taskId)
-	if err == datastore.ErrNotFound {
-		state = `{"active":false,"queued":false,"completed":false,"progress":null,"eta":null,"live_preview":null,"id_live_preview":-1,"textinfo":"Waiting..."}`
-		a.Datastore.Put(taskId, state)
-	} else if err != nil {
-		return err
-	}
-	//return c.JSON(http.StatusOK, state)
-
-	a.Proxy.ServeHTTP(c.Response(), c.Request())
-	return nil
-}
-
 // updateTaskProgress get the task progress info from downstream GPUServer and update it to the DB.
-func (a *Agent) updateTaskProgress(taskId string) error {
-	client := &http.Client{}
-	previewId := 0
+func (a *Agent) updateTaskProgress(ctx context.Context, taskId string) error {
+	client := a.HttpClient
+	var previewId float64
+	notifyDone := false
 	for {
+		select {
+		case <-ctx.Done():
+			notifyDone = true
+		default:
+			// Do nothing, go to the next
+		}
 		// TODO: Make the task progress url configurable.
-		reqBody := fmt.Sprintf(`{"id_task":"%s","id_live_preview":%d}`, taskId, previewId)
+		reqBody := fmt.Sprintf(`{"id_task":"%s","id_live_preview":%f}`, taskId, previewId)
 		req, err := http.NewRequest(
-			"GET", "http://sd.fc-stable-diffusion.1050834996213541.cn-hangzhou.fc.devsapp.net/internal/progress", bytes.NewBuffer([]byte(reqBody)))
+			"POST", "http://sd.fc-stable-diffusion.1050834996213541.cn-hangzhou.fc.devsapp.net/internal/progress", bytes.NewBuffer([]byte(reqBody)))
 		if err != nil {
 			return err
 		}
@@ -123,14 +93,14 @@ func (a *Agent) updateTaskProgress(taskId string) error {
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
 
 		// Update the task progress to DB.
 		a.Datastore.Put(taskId, string(body))
-		a.Echo.Logger.Infof("update task progress: %s", string(body))
+		a.Echo.Logger.Debugf("update task progress: %s", string(body))
 
 		var m map[string]interface{}
 		if err := json.Unmarshal(body, &m); err != nil {
@@ -143,9 +113,8 @@ func (a *Agent) updateTaskProgress(taskId string) error {
 			return fmt.Errorf("can not find id_live_preview in /internal/progress response")
 		}
 		var ok bool
-		previewId, ok = val.(int)
-		if !ok {
-			return fmt.Errorf("wrong id_live_preview: %v", previewId)
+		if previewId, ok = val.(float64); !ok {
+			return fmt.Errorf("invalid id_live_preview: %v, expect type: float64, actual type: %s", val, reflect.TypeOf(val))
 		}
 
 		// Return if complete.
@@ -158,8 +127,17 @@ func (a *Agent) updateTaskProgress(taskId string) error {
 			return fmt.Errorf("wrong completed: %v", completed)
 		}
 		if completed {
+			a.Echo.Logger.Infof("the task %s is done", taskId)
 			return nil
 		}
+		// notifyDone means the update-progress is notified by other goroutine to finish,
+		// either because the task has been aborted or succeed.
+		if notifyDone {
+			a.Echo.Logger.Infof("the task %s is done, either success or failed", taskId)
+			return nil
+		}
+
+		time.Sleep(500 * time.Millisecond)
 	}
 }
 
@@ -217,18 +195,19 @@ func (a *Agent) queueJoinHandler(c echo.Context) error {
 				}
 				var taskId string
 				if data, ok := m["data"]; ok {
-					if l, ok := data.([]string); ok {
-						taskId = l[0]
-					} else {
-						a.Echo.Logger.Errorf("invalid websocket message: %v", string(message))
+					if l, ok := data.([]interface{}); ok {
+						if len(l) > 0 {
+							taskId, _ = l[0].(string)
+						}
 					}
 				}
+				a.Echo.Logger.Infof("websocket message: %v %v", string(message), m)
 
 				// Launch update-task goroutine if necessary.
 				if taskId != "" {
 					go func() {
 						a.Echo.Logger.Infof("launch update-task goroutine for task %s", taskId)
-						err := a.updateTaskProgress(taskId)
+						err := a.updateTaskProgress(ctx, taskId)
 						if err != nil {
 							a.Echo.Logger.Errorf("update task progress error: %v", err)
 						}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -1,48 +1,91 @@
 package proxy
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httputil"
 	"net/url"
 
+	"github.com/hryang/stable-diffusion-webui-proxy/pkg/datastore"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
 
 type Server struct {
-	Endpoint string     // the target server's endpoint
-	Echo     *echo.Echo // the echo server for reverse proxy
+	Target    *url.URL            // the target server address
+	Echo      *echo.Echo          // the echo server for reverse proxy
+	Datastore datastore.Datastore // the datastore to store the task states
 }
 
 func NewServer(endpoint string) *Server {
 	s := &Server{
-		Endpoint: endpoint,
-		Echo:     echo.New(),
+		Echo: echo.New(),
 	}
 
 	s.Echo.Debug = true
-	target, _ := url.Parse(s.Endpoint)
+	s.Target, _ = url.Parse(endpoint)
 
 	s.Echo.Use(middleware.Logger())
 	s.Echo.Use(middleware.Recover())
 
-	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy := httputil.NewSingleHostReverseProxy(s.Target)
+
+	s.Datastore = datastore.NewSQLiteDatastore("./test.db")
+
+	s.Echo.POST("/internal/progress", s.progressHandler)
 
 	// Handler for all other cases.
 	s.Echo.Any("/*", func(c echo.Context) error {
 		req := c.Request()
-		req.Host = target.Host
-		req.URL.Host = target.Host
-		req.URL.Scheme = target.Scheme
-		s.Echo.Logger.Info(req)
+		req.Host = s.Target.Host
+		req.URL.Host = s.Target.Host
+		req.URL.Scheme = s.Target.Scheme
 		proxy.ServeHTTP(c.Response(), c.Request())
 		return nil
 	})
 
-	s.Echo.Logger.Infof("Create the reverse proxy for %s", s.Endpoint)
+	s.Echo.Logger.Infof("Create the reverse proxy for %s", endpoint)
 
 	return s
 }
 
 func (s *Server) Start(address string) error {
 	return s.Echo.Start(address)
+}
+
+func (s *Server) Close() error {
+	return s.Datastore.Close()
+}
+
+func (s *Server) progressHandler(c echo.Context) error {
+	req := c.Request()
+	req.Host = s.Target.Host
+	req.URL.Host = s.Target.Host
+	req.URL.Scheme = s.Target.Scheme
+
+	// Get task id from request.
+	body, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		return err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return err
+	}
+	taskId := m["id_task"].(string)
+
+	// The http body is a stream and can be read once only.
+	// So we have to restore the request body for serving.
+	c.Request().Body = io.NopCloser(bytes.NewBuffer(body))
+
+	// Get task state from DB.
+	state, err := s.Datastore.Get(taskId)
+	if err == datastore.ErrNotFound {
+		state = `{"active":false,"queued":false,"completed":false,"progress":null,"eta":null,"live_preview":null,"id_live_preview":-1,"textinfo":"Waiting..."}`
+	} else if err != nil {
+		return err
+	}
+	return c.Blob(http.StatusOK, "application/json", []byte(state))
 }


### PR DESCRIPTION
Implement two components:

1. Agent: Query the task states from sd-webui server periodically and update it to the  DB.
2. Proxy: Query the task states from DB and return it to client.